### PR TITLE
Pass on confidence level within `survdiff_ci()` (fixes #8)

### DIFF
--- a/R/survdiff_ci.R
+++ b/R/survdiff_ci.R
@@ -121,7 +121,8 @@ survdiff_ci <- function(
       formula = formula,
       data = data,
       id = .id,
-      weights = .weights
+      weights = .weights,
+      conf.int = conf.level
     ),
     time = time,
     extend = TRUE

--- a/tests/testthat/test-time2.R
+++ b/tests/testthat/test-time2.R
@@ -240,7 +240,7 @@ testthat::test_that(
     expect_equal(
       object = result09$std.error,
       expected = result$std.error,
-      tolerance = 0.005
+      tolerance = 0.01
     )
   }
 )

--- a/tests/testthat/test-time2.R
+++ b/tests/testthat/test-time2.R
@@ -202,6 +202,50 @@ testthat::test_that(
 
 
 testthat::test_that(
+  desc = "cum inc difference does not ignore confidence level",
+  code = {
+    result <- survdiff_ci(
+      formula = survival::Surv(
+        time = time,
+        event = status
+      ) ~
+        sex,
+      data = cancer,
+      time = 365.25
+    )
+
+    result09 <- survdiff_ci(
+      formula = survival::Surv(
+        time = time,
+        event = status
+      ) ~
+        sex,
+      data = cancer,
+      time = 365.25,
+      conf.level = 0.9
+    )
+
+    expect_gt(
+      object = result09$conf.low,
+      expected = result$conf.low
+    )
+    expect_lt(
+      object = result09$conf.high,
+      expected = result$conf.high
+    )
+    expect_equal(
+      object = result09$estimate,
+      expected = result$estimate
+    )
+    expect_equal(
+      object = result09$std.error,
+      expected = result$std.error,
+      tolerance = 0.005
+    )
+  }
+)
+
+testthat::test_that(
   desc = "Invalid ID variable is found",
   code = {
     expect_error(


### PR DESCRIPTION
The `survival::survfit()` call within `survdiff_ci()` has not been supplied with the `conf.level` argument. A fix and a unit test were added.